### PR TITLE
Change project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Binary file
-flotta-dev-cli
+bin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 ### Build
 
-Build the project by running: `go build .`
+Build the project by running: `make build`
 
 ## Contribute
 
@@ -24,4 +24,4 @@ Build the project by running: `go build .`
   This will create a new file named `<subcommand name>.go` inside the `cmd` directory.
 
 ### Apply the changes
-Once you have finished editing the new file, re-build the project: `go build .`.
+Once you have finished editing the new file, re-build the project: `make build`.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+##@ Build
+
+build:
+	go build -mod=vendor -o bin/flotta main.go
+
 ##@ Development
 
 generate-tools:

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repo has the developer CLI for [project-flotta.io](https://github.com/proje
 
 ### Build
 
-Build the project by running: `go build .`
+Build the project by running: `make build`
 
 ## Usage
 
 Use the developer CLI commands by running: 
 
-`./flotta-dev-cli <command> <subcommand>`
+`./bin/flotta <command> <subcommand>`
 
 For example:
-`./flotta-dev-cli add edgedevice`
+`./bin/flotta add edgedevice`

--- a/commands/add.go
+++ b/commands/add.go
@@ -14,24 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package commands
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Adds a new edgedevice",
-	Long: `Adds a new edgedevice"`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("edgedevice called")
-	},
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new flotta resource",
+	Long: `Use the add command to add a flotta resource, such as edgedevice, edgeworkload or edgedeviceset`,
 }
 
 func init() {
-	addCmd.AddCommand(edgedeviceCmd)
+	rootCmd.AddCommand(addCmd)
 }

--- a/commands/edgedevice.go
+++ b/commands/edgedevice.go
@@ -14,19 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package commands
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
-// addCmd represents the add command
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a new flotta resource",
-	Long: `Use the add command to add a flotta resource, such as edgedevice, edgeworkload or edgedeviceset`,
+// edgedeviceCmd represents the edgedevice command
+var edgedeviceCmd = &cobra.Command{
+	Use:   "edgedevice",
+	Short: "Adds a new edgedevice",
+	Long: `Adds a new edgedevice"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("edgedevice called")
+	},
 }
 
 func init() {
-	rootCmd.AddCommand(addCmd)
+	addCmd.AddCommand(edgedeviceCmd)
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package commands
 
 import (
 	"fmt"
@@ -39,7 +39,7 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	//	Run: func(commands *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package main
 
-import "github.com/arielireni/flotta-dev-cli/cmd"
+import "github.com/arielireni/flotta-dev-cli/commands"
 
 func main() {
-	cmd.Execute()
+	commands.Execute()
 }


### PR DESCRIPTION
Add bin directory and `make build` in order to build the project's binary inside `bin/`.

Rename cmd directory to commands.

Signed-off-by: arielireni <aireni@redhat.com>