### PR TITLE
Enable cobra-cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,55 @@ Build the project by running: `make build`
 
 ### Add a new command
 
-- To add a new command run: `cobra add <command name>`.
+In order to use `cobra-cli` and generate a new command, change your working path to the `internal` directory. 
 
-  This will create a new file named `<command name>.go` inside the `cmd` directory.
+#### Parent command
 
-- To add a new subcommand run: `cobra add <subcommand name> -p '<command>Cmd'`.
+1. Create a new directory with the name of the parent command.
 
-  This will create a new file named `<subcommand name>.go` inside the `cmd` directory.
+    For example, in order to add the command `add edgedevice`, create a new directory under `internal/` named `add`.
+
+
+2. Import the new directory in the `main.go` file, by adding the next line to the import section:
+   
+    `_ "github.com/arielireni/flotta-dev-cli/internal/cmd/<parent command name>"`
+
+
+3. Use the cobra generator to create the new command:
+
+   `cobra add <command name>`
+
+     This will create a new file named `<parent command name>.go` inside the `cmd` directory.
+
+
+4. Move the new file to the parent command directory.
+
+#### Sub-command
+
+1. Use the cobra generator to create the new command:
+
+    `cobra add <sub-command name> -p '<command>Cmd'`
+
+      This will create a new file named `<sub-command name>.go` inside the `cmd` directory.
+
+
+2. Move the new file to the parent command directory.
+
+### Edit
+
+#### New command
+
+1. Change `rootCmd` to public by renaming it to `RootCmd`, so it will be importable in the `<parent command name>.go` file.
+
+
+2. Make your own changes in the new generated file.
+
+#### Existing command
+
+- To edit parent command, edit the file `<parent command>.go` in `/internal/cmd/<parent command name>`. 
+
+- To edit sub-command, edit the file `<sub-command name>.go` in `/internal/cmd/<parent command name>`.
 
 ### Apply the changes
-Once you have finished editing the new file, re-build the project: `make build`.
+
+Once you have finished editing the files, re-build the project: `make build`.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ##@ Build
 
-build:
+build: generate-tools
 	go build -mod=vendor -o bin/flotta main.go
 
 ##@ Development

--- a/internal/cmd/add/add.go
+++ b/internal/cmd/add/add.go
@@ -14,24 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package commands
+package add
 
 import (
-	"fmt"
-
+	"github.com/arielireni/flotta-dev-cli/internal/cmd"
 	"github.com/spf13/cobra"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Adds a new edgedevice",
-	Long: `Adds a new edgedevice"`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("edgedevice called")
-	},
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new flotta resource",
+	Long: `Use the add command to add a flotta resource, such as edgedevice, edgeworkload or edgedeviceset`,
 }
 
 func init() {
-	addCmd.AddCommand(edgedeviceCmd)
+	cmd.RootCmd.AddCommand(addCmd)
 }

--- a/internal/cmd/add/edgedevice.go
+++ b/internal/cmd/add/edgedevice.go
@@ -14,19 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package commands
+package add
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
-// addCmd represents the add command
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a new flotta resource",
-	Long: `Use the add command to add a flotta resource, such as edgedevice, edgeworkload or edgedeviceset`,
+// edgedeviceCmd represents the edgedevice command
+var edgedeviceCmd = &cobra.Command{
+	Use:   "edgedevice",
+	Short: "Adds a new edgedevice",
+	Long: `Adds a new edgedevice"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("edgedevice called")
+	},
 }
 
 func init() {
-	rootCmd.AddCommand(addCmd)
+	addCmd.AddCommand(edgedeviceCmd)
 }

--- a/internal/cmd/delete/delete.go
+++ b/internal/cmd/delete/delete.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"fmt"
+	"github.com/arielireni/flotta-dev-cli/internal/cmd"
+
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a flotta resource",
+	Long: `Use the delete command to delete a flotta resource, such as edgedevice, edgeworkload or edgedeviceset`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("delete called")
+	},
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(deleteCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deleteCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package commands
+package cmd
 
 import (
 	"fmt"
@@ -27,16 +27,11 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "flotta-dev-cli",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "flotta",
+	Short: "CLI for project-flotta.io",
+	Long: `CLI for project-flotta.io`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(commands *cobra.Command, args []string) { },
@@ -45,7 +40,7 @@ to quickly create a Cobra application.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -58,11 +53,11 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.flotta-dev-cli.yaml)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.flotta-dev-cli.yaml)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/main.go
+++ b/main.go
@@ -15,8 +15,12 @@ limitations under the License.
 */
 package main
 
-import "github.com/arielireni/flotta-dev-cli/commands"
+import (
+	"github.com/arielireni/flotta-dev-cli/internal/cmd"
+	_ "github.com/arielireni/flotta-dev-cli/internal/cmd/add"
+	_ "github.com/arielireni/flotta-dev-cli/internal/cmd/delete"
+)
 
 func main() {
-	commands.Execute()
+	cmd.Execute()
 }


### PR DESCRIPTION
Enabled cobra-cli after re-organize the project's structure.

Added documentation for contributing with the cobra-cli.

Added `delete` directory and generated `delete.go` file for future use.

Signed-off-by: arielireni <aireni@redhat.com>