### PR TITLE
Remove `edge` prefix in commands syntax

### DIFF
--- a/internal/cmd/add/device.go
+++ b/internal/cmd/add/device.go
@@ -1,5 +1,3 @@
-package delete
-
 /*
 Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 
@@ -16,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package add
 
 import (
 	"fmt"
@@ -23,10 +22,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// edgeworkloadCmd represents the edgeworkload command
-var edgeworkloadCmd = &cobra.Command{
-	Use:   "edgeworkload",
-	Short: "Delete edgeworkload",
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "Adds a new device",
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
@@ -35,23 +34,26 @@ var edgeworkloadCmd = &cobra.Command{
 			return
 		}
 
-		workload, err := resources.NewEdgeWorkload(client)
+		device, err := resources.NewEdgeDevice(client, args[0])
 		if err != nil {
-			fmt.Printf("NewEdgeWorkload failed: %v\n", err)
+			fmt.Printf("NewEdgeDevice failed: %v\n", err)
 			return
 		}
 
-		err = workload.Remove(args[0])
+		err = device.Register()
 		if err != nil {
-			fmt.Printf("Remove workload failed: %v\n", err)
+			// if device.Register() failed, remove the container
+			device.Remove()
+
+			fmt.Printf("Register failed: %v\n", err)
 			return
 		}
 
-		fmt.Printf("workload '%v' was deleted \n", args[0])
+		fmt.Printf("device '%v' was added \n", device.GetName())
 	},
 }
 
 func init() {
-	// subcommand of delete
-	deleteCmd.AddCommand(edgeworkloadCmd)
+	// subcommand of add
+	addCmd.AddCommand(deviceCmd)
 }

--- a/internal/cmd/add/workload.go
+++ b/internal/cmd/add/workload.go
@@ -31,16 +31,15 @@ const (
 	defaultImage = "quay.io/project-flotta/nginx:1.21.6"
 )
 
-// edgeworkloadCmd represents the edgeworkload command
+// workloadCmd represents the workload command
 var (
 	deviceID      string
 	workloadImage string
 	workloadName  string
 
-	edgeworkloadCmd = &cobra.Command{
-		Use:   "edgeworkload",
-		Short: "Adds a new edgeworkload",
-		Long:  `Adds a new edgeworkload"`,
+	workloadCmd = &cobra.Command{
+		Use:   "workload",
+		Short: "Adds a new workload",
 		Run: func(cmd *cobra.Command, args []string) {
 			if workloadImage == "" {
 				workloadImage = defaultImage
@@ -88,22 +87,22 @@ var (
 				return
 			}
 
-			fmt.Printf("edgeworkload '%s' was added to device '%s'\n", workloadName, deviceID)
+			fmt.Printf("workload '%s' was added to device '%s'\n", workloadName, deviceID)
 		},
 	}
 )
 
 func init() {
 	// subcommand of add
-	addCmd.AddCommand(edgeworkloadCmd)
+	addCmd.AddCommand(workloadCmd)
 
 	// define command flags
-	edgeworkloadCmd.PersistentFlags().StringVarP(&deviceID, "device", "d", "", "device to run the container workload on")
-	edgeworkloadCmd.PersistentFlags().StringVarP(&workloadImage, "image", "i", "", "image of the workload")
-	edgeworkloadCmd.PersistentFlags().StringVarP(&workloadName, "name", "n", "", "name of the workload")
+	workloadCmd.PersistentFlags().StringVarP(&deviceID, "device", "d", "", "device to run the container workload on")
+	workloadCmd.PersistentFlags().StringVarP(&workloadImage, "image", "i", "", "image of the workload")
+	workloadCmd.PersistentFlags().StringVarP(&workloadName, "name", "n", "", "name of the workload")
 
 	// mark device flag as required
-	edgeworkloadCmd.MarkPersistentFlagRequired("device")
+	workloadCmd.MarkPersistentFlagRequired("device")
 }
 
 func RandomSuffix() string {

--- a/internal/cmd/delete/device.go
+++ b/internal/cmd/delete/device.go
@@ -1,4 +1,4 @@
-package stop
+package delete
 
 /*
 Copyright © 2022 NAME HERE <EMAIL ADDRESS>
@@ -18,16 +18,16 @@ limitations under the License.
 
 
 import (
-	"fmt"
-	"github.com/arielireni/flotta-dev-cli/internal/resources"
-	"github.com/spf13/cobra"
+"fmt"
+"github.com/arielireni/flotta-dev-cli/internal/resources"
+"github.com/spf13/cobra"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Stops a container of existing edgedevice",
-	Long: `Stops a container of existing edgedevice"`,
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "Delete device",
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -41,17 +41,23 @@ var edgedeviceCmd = &cobra.Command{
 			return
 		}
 
-		err = device.Stop()
+		err = device.Unregister()
 		if err != nil {
-			fmt.Printf("Stop failed: %v\n", err)
+			fmt.Printf("Unregister failed: %v\n", err)
 			return
 		}
 
-		fmt.Printf("edgedevice '%v' was stopped \n", device.GetName())
+		err = device.Remove()
+		if err != nil {
+			fmt.Printf("Remove failed: %v\n", err)
+			return
+		}
+
+		fmt.Printf("device '%v' was deleted \n", device.GetName())
 	},
 }
 
 func init() {
-	// subcommand of stop
-	stopCmd.AddCommand(edgedeviceCmd)
+	// subcommand of delete
+	deleteCmd.AddCommand(deviceCmd)
 }

--- a/internal/cmd/delete/workload.go
+++ b/internal/cmd/delete/workload.go
@@ -18,16 +18,16 @@ limitations under the License.
 
 
 import (
-"fmt"
-"github.com/arielireni/flotta-dev-cli/internal/resources"
-"github.com/spf13/cobra"
+	"fmt"
+	"github.com/arielireni/flotta-dev-cli/internal/resources"
+	"github.com/spf13/cobra"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Delete edgedevice",
-	Long: `Deletes an edgedevice"`,
+// workloadCmd represents the workload command
+var workloadCmd = &cobra.Command{
+	Use:   "workload",
+	Short: "Delete workload",
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -35,29 +35,23 @@ var edgedeviceCmd = &cobra.Command{
 			return
 		}
 
-		device, err := resources.NewEdgeDevice(client, args[0])
+		workload, err := resources.NewEdgeWorkload(client)
 		if err != nil {
-			fmt.Printf("NewEdgeDevice failed: %v\n", err)
+			fmt.Printf("NewEdgeWorkload failed: %v\n", err)
 			return
 		}
 
-		err = device.Unregister()
+		err = workload.Remove(args[0])
 		if err != nil {
-			fmt.Printf("Unregister failed: %v\n", err)
+			fmt.Printf("Remove workload failed: %v\n", err)
 			return
 		}
 
-		err = device.Remove()
-		if err != nil {
-			fmt.Printf("Remove failed: %v\n", err)
-			return
-		}
-
-		fmt.Printf("edgedevice '%v' was deleted \n", device.GetName())
+		fmt.Printf("workload '%v' was deleted \n", args[0])
 	},
 }
 
 func init() {
 	// subcommand of delete
-	deleteCmd.AddCommand(edgedeviceCmd)
+	deleteCmd.AddCommand(workloadCmd)
 }

--- a/internal/cmd/list/device.go
+++ b/internal/cmd/list/device.go
@@ -30,11 +30,11 @@ import (
 	"time"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Adds a new edgedevice",
-	Long:  `Adds a new edgedevice"`,
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "list device",
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -75,5 +75,5 @@ var edgedeviceCmd = &cobra.Command{
 
 func init() {
 	// subcommand of list
-	listCmd.AddCommand(edgedeviceCmd)
+	listCmd.AddCommand(deviceCmd)
 }

--- a/internal/cmd/start/device.go
+++ b/internal/cmd/start/device.go
@@ -23,11 +23,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Adds a new edgedevice",
-	Long: `Adds a new edgedevice"`,
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "start device",
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -47,11 +47,11 @@ var edgedeviceCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("edgedevice '%v' was started \n", device.GetName())
+		fmt.Printf("device '%v' was started \n", device.GetName())
 	},
 }
 
 func init() {
 	// subcommand of start
-	startCmd.AddCommand(edgedeviceCmd)
+	startCmd.AddCommand(deviceCmd)
 }

--- a/internal/cmd/stop/device.go
+++ b/internal/cmd/stop/device.go
@@ -1,3 +1,5 @@
+package stop
+
 /*
 Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 
@@ -14,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package add
 
 import (
 	"fmt"
@@ -22,11 +23,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// edgedeviceCmd represents the edgedevice command
-var edgedeviceCmd = &cobra.Command{
-	Use:   "edgedevice",
-	Short: "Adds a new edgedevice",
-	Long: `Adds a new edgedevice"`,
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "stops a device",
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client, err := resources.NewClient()
 		if err != nil {
@@ -40,20 +41,17 @@ var edgedeviceCmd = &cobra.Command{
 			return
 		}
 
-		err = device.Register()
+		err = device.Stop()
 		if err != nil {
-			// if device.Register() failed, remove the container
-			device.Remove()
-
-			fmt.Printf("Register failed: %v\n", err)
+			fmt.Printf("Stop failed: %v\n", err)
 			return
 		}
 
-		fmt.Printf("edgedevice '%v' was added \n", device.GetName())
+		fmt.Printf("edgedevice '%v' was stopped \n", device.GetName())
 	},
 }
 
 func init() {
-	// subcommand of add
-	addCmd.AddCommand(edgedeviceCmd)
+	// subcommand of stop
+	stopCmd.AddCommand(deviceCmd)
 }


### PR DESCRIPTION
Replaced `<command> edgedevice/edgeworkload` with `<command> device/workload`.
Added arguments validation.
Removed commands long description.
Updated commands short description.

Signed-off-by: arielireni <aireni@redhat.com>